### PR TITLE
add the possibility to deactivate the simpleAnnotationReader

### DIFF
--- a/src/DoctrinePackage.php
+++ b/src/DoctrinePackage.php
@@ -51,8 +51,14 @@
                     }
                 });
 
+                $useSimpleAnnotationReader = true;
+                if(isset($params['use_simple_annotation_reader']))
+                {
+                    $useSimpleAnnotationReader = (bool) $params['use_simple_annotation_reader'];
+                }
+
                 // TODO: handle isDev depending on app config
-                $emConfig = Setup::createAnnotationMetadataConfiguration((array) $entitiesPaths, true);
+                $emConfig = Setup::createAnnotationMetadataConfiguration((array) $entitiesPaths, true, null ,null, $useSimpleAnnotationReader);
                 $emConfig->setNamingStrategy(new UnderscoreNamingStrategy());
                 $em       = EntityManager::create($params, $emConfig);
 

--- a/tests/Doctrine/DoctrinePackageTest.php
+++ b/tests/Doctrine/DoctrinePackageTest.php
@@ -12,6 +12,8 @@ use ObjectivePHP\Package\Doctrine\DoctrinePackage;;
 class DoctrinePackageTest extends \PHPUnit_Framework_TestCase
 {
 
+    protected $app;
+    
     public function testPackageIsCallable()
     {
         $package = new DoctrinePackage();
@@ -20,12 +22,7 @@ class DoctrinePackageTest extends \PHPUnit_Framework_TestCase
 
     public function testBuildEntityManagers()
     {
-        $package = new DoctrinePackage();
-
-        $app = $this->getMockBuilder(AbstractApplication::class)->setMethods(['getConfig'])->getMockForAbstractClass();
-        $config = $this->getMockBuilder(Config::class)->getMock();
-
-        $config->expects($this->once())->method('subset')->willReturn(
+        $this->buildConfig(
             ['test' => [
                 'entities.locations' => __DIR__,
                 'driver' => 'pdo_sqlite',
@@ -33,18 +30,67 @@ class DoctrinePackageTest extends \PHPUnit_Framework_TestCase
                 'mapping_types' => [
                     'enum' => 'string',
                     'test' => IntegerType::class
-                ]
+                ],
             ]]
         );
-        $app->expects($this->once())->method('getConfig')->willReturn($config);
 
-        $package->buildEntityManagers($app);
-
-        $this->assertTrue($app->getServicesFactory()->has('doctrine.em.test'));
 
         /** @var EntityManager $em */
-        $em = $app->getServicesFactory()->get('doctrine.em.test');
+        $em = $this->app->getServicesFactory()->get('doctrine.em.test');
         $this->assertEquals('string', $em->getConnection()->getDatabasePlatform()->getDoctrineTypeMapping('enum'));
         $this->assertEquals('test', $em->getConnection()->getDatabasePlatform()->getDoctrineTypeMapping('test'));
+        $this->assertAttributeInstanceOf('Doctrine\Common\Annotations\SimpleAnnotationReader', 'delegate', $em->getConfiguration()->getMetaDataDriverImpl()->getReader());
     }
+
+    public function testBuildEntityManagersWithSimpleAnnotationReader()
+    {
+        $this->buildConfig(
+            ['test' => [
+                'entities.locations' => __DIR__,
+                'driver' => 'pdo_sqlite',
+                'memory' => true,
+                'use_simple_annotation_reader' => true
+            ]]
+        );
+
+
+        /** @var EntityManager $em */
+        $em = $this->app->getServicesFactory()->get('doctrine.em.test');
+        $this->assertAttributeInstanceOf('Doctrine\Common\Annotations\SimpleAnnotationReader', 'delegate', $em->getConfiguration()->getMetaDataDriverImpl()->getReader());
+
+    }
+
+    public function testBuildEntityManagersWithAnnotationReader()
+    {
+        $this->buildConfig(
+            ['test' => [
+                'entities.locations' => __DIR__,
+                'driver' => 'pdo_sqlite',
+                'memory' => true,
+                'use_simple_annotation_reader' => false
+            ]]
+        );
+
+        /** @var EntityManager $em */
+        $em = $this->app->getServicesFactory()->get('doctrine.em.test');
+        $this->assertAttributeInstanceOf('Doctrine\Common\Annotations\AnnotationReader', 'delegate', $em->getConfiguration()->getMetaDataDriverImpl()->getReader());
+
+    }
+
+    protected function buildConfig(array $configArray) 
+    {
+        $package = new DoctrinePackage();
+
+        $this->app = $this->getMockBuilder(AbstractApplication::class)->setMethods(['getConfig'])->getMockForAbstractClass();
+        $config = $this->getMockBuilder(Config::class)->getMock();
+
+        $config->expects($this->once())->method('subset')->willReturn($configArray);
+        $this->app->expects($this->once())->method('getConfig')->willReturn($config);
+        
+        $package->buildEntityManagers($this->app);
+
+        $this->assertTrue($this->app->getServicesFactory()->has('doctrine.em.test'));        
+
+    }
+
 }


### PR DESCRIPTION
with that, in the doctrine configuration file, we can do :

```
return [
    new EntityManager('default',
        [
            'use_simple_annotation_reader'   => false
        ]),
];
```

to deactivate it.
by default it will be true (for backward compatibility) 
